### PR TITLE
disables response buffering to temporary files

### DIFF
--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -2,3 +2,4 @@ client_max_body_size 10m;
 proxy_request_buffering off;
 client_header_buffer_size 5120k;
 large_client_header_buffers 16 5120k;
+proxy_max_temp_file_size 0;


### PR DESCRIPTION
Disable buffering warning by disabling nginx buffering to temporary files.